### PR TITLE
Editor: avoid error when mediadir does not exist

### DIFF
--- a/coder-base/apps/editor/app.js
+++ b/coder-base/apps/editor/app.js
@@ -335,7 +335,7 @@ exports.listMedia = function( appname ) {
     var path = process.cwd(); //root application path. different from __dirname
     var mediadir = path + "/static/apps/" + appname + "/media/";
     var media = {};
-    var files = fs.readdirSync(mediadir);
+    var files = fs.existsSync(mediadir) ? fs.readdirSync(mediadir) : {};
     for ( var x in files ) {
         var filename = files[x];
         var info = fs.statSync( mediadir + filename );


### PR DESCRIPTION
Some apps do not have a media dir under static/apps/<app_name> for
example eyeball and hello_coder. When you try to edit the apps with app
editor, there is an error display in the consol. The fix checks if the
folder exists before reading it.

Error in the conle is :

```
16 Sep 23:20:46 - GET: edit/hello_coder editor
16 Sep 23:20:47 - GET: api/metadata/get/hello_coder editor
16 Sep 23:20:47 - GET: api/media/list/hello_coder editor
Error: ENOENT, no such file or directory '/Users/vincent/dev/coder/coder-base/static/apps/hello_coder/media/'
    at Object.fs.readdirSync (fs.js:654:18)
    at Object.exports.listMedia (/Users/vincent/dev/coder/coder-base/apps/editor/app.js:338:20)
    at Object.exports.api_media_list_handler (/Users/vincent/dev/coder/coder-base/apps/editor/app.js:107:21)
    at apphandler (/Users/vincent/dev/coder/coder-base/server.js:111:46)
    at /Users/vincent/dev/coder/coder-base/server.js:255:60
    at callbacks (/Users/vincent/dev/coder/coder-base/node_modules/express/lib/router/index.js:161:37)
    at param (/Users/vincent/dev/coder/coder-base/node_modules/express/lib/router/index.js:135:11)
    at pass (/Users/vincent/dev/coder/coder-base/node_modules/express/lib/router/index.js:142:5)
    at Router._dispatch (/Users/vincent/dev/coder/coder-base/node_modules/express/lib/router/index.js:170:5)
    at Object.router (/Users/vincent/dev/coder/coder-base/node_modules/express/lib/router/index.js:33:10)
16 Sep 23:20:47 - GET: api/getcode/hello_coder editor
```
